### PR TITLE
Ensure that non-finite edge_factors result in errors

### DIFF
--- a/R/calculate_boundaries.r
+++ b/R/calculate_boundaries.r
@@ -63,8 +63,8 @@ calculate_boundaries.Raster <- function(x, matrix = TRUE, sparse = TRUE,
   assert_that(assertthat::is.flag(matrix),
               assertthat::is.flag(sparse),
               assertthat::is.flag(triangular),
-              assertthat::is.number(edge_factor))
-  stopifnot(is.finite(edge_factor))
+              assertthat::is.number(edge_factor),
+              all(is.finite(edge_factor)))
 
   # shared boundaries
   ud <- matrix(c(NA, NA, NA, 1, 0, 1, NA, NA, NA), 3, 3)

--- a/R/calculate_boundaries.r
+++ b/R/calculate_boundaries.r
@@ -64,6 +64,7 @@ calculate_boundaries.Raster <- function(x, matrix = TRUE, sparse = TRUE,
               assertthat::is.flag(sparse),
               assertthat::is.flag(triangular),
               assertthat::is.number(edge_factor))
+  stopifnot(is.finite(edge_factor))
 
   # shared boundaries
   ud <- matrix(c(NA, NA, NA, 1, 0, 1, NA, NA, NA), 3, 3)


### PR DESCRIPTION
Fix #21.

I have used `stopifnot` because I can't find an assertion in `assertthat` that handles `Inf` values. 